### PR TITLE
[FEAT] リンク集機能を実装

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -251,7 +251,8 @@
       "Bash(./ngrok config:*)",
       "Bash(./ngrok http 8080)",
       "Bash(npx localtunnel:*)",
-      "Bash(./ngrok version)"
+      "Bash(./ngrok version)",
+      "Bash(gh repo view:*)"
     ],
     "deny": [
       "Bash(sudo:*)",

--- a/api/go.mod
+++ b/api/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/jmoiron/sqlx v1.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.4 // indirect
 	github.com/leodido/go-urn v1.2.4 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -1,3 +1,4 @@
+filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
@@ -33,6 +34,7 @@ github.com/go-playground/validator/v10 v10.14.0 h1:vgvQWe3XCz3gIeFDm/HnTIbj6UGmg
 github.com/go-playground/validator/v10 v10.14.0/go.mod h1:9iXMNT7sEkjXb0I+enO7QXmzG6QCsPWY4zveKFVRSyU=
 github.com/go-redis/redis/v8 v8.11.5 h1:AcZZR7igkdvfVmQTPnu9WE37LRrO/YrBH5zWyjDC0oI=
 github.com/go-redis/redis/v8 v8.11.5/go.mod h1:gREzHqY1hg6oD9ngVRbLStwAWKhA0FEgq8Jd4h5lpwo=
+github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
@@ -49,6 +51,8 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/jmoiron/sqlx v1.4.0 h1:1PLqN7S1UYp5t4SrVVnt4nUVNemrDAtxlulVe+Qgm3o=
+github.com/jmoiron/sqlx v1.4.0/go.mod h1:ZrZ7UsYB/weZdl2Bxg6jCRO9c3YHl8r3ahlKmRT4JLY=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
@@ -61,6 +65,7 @@ github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/api/internal/domain/entity/link.go
+++ b/api/internal/domain/entity/link.go
@@ -1,0 +1,60 @@
+package entity
+
+import (
+	"time"
+	
+	"github.com/google/uuid"
+)
+
+// Link リンクエンティティ
+type Link struct {
+	ID              int       `json:"id" db:"id"`
+	Title           string    `json:"title" db:"title"`
+	URL             string    `json:"url" db:"url"`
+	Description     *string   `json:"description" db:"description"`
+	Platform        string    `json:"platform" db:"platform"`
+	IconName        *string   `json:"icon_name" db:"icon_name"`
+	BackgroundColor string    `json:"background_color" db:"background_color"`
+	TextColor       string    `json:"text_color" db:"text_color"`
+	OrderIndex      int       `json:"order_index" db:"order_index"`
+	IsActive        bool      `json:"is_active" db:"is_active"`
+	UserID          uuid.UUID `json:"user_id" db:"user_id"`
+	CreatedAt       time.Time `json:"created_at" db:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at" db:"updated_at"`
+}
+
+// LinkPlatform プラットフォーム定数
+type LinkPlatform string
+
+const (
+	PlatformTwitter   LinkPlatform = "twitter"
+	PlatformInstagram LinkPlatform = "instagram"
+	PlatformGitHub    LinkPlatform = "github"
+	PlatformLINE      LinkPlatform = "line"
+	PlatformWebsite   LinkPlatform = "website"
+	PlatformYouTube   LinkPlatform = "youtube"
+	PlatformTikTok    LinkPlatform = "tiktok"
+	PlatformLinkedIn  LinkPlatform = "linkedin"
+)
+
+// GetDefaultColors プラットフォームのデフォルト色を取得
+func (p LinkPlatform) GetDefaultColors() (background, text string) {
+	switch p {
+	case PlatformTwitter:
+		return "#1DA1F2", "#FFFFFF"
+	case PlatformInstagram:
+		return "#E4405F", "#FFFFFF"
+	case PlatformGitHub:
+		return "#333333", "#FFFFFF"
+	case PlatformLINE:
+		return "#00C300", "#FFFFFF"
+	case PlatformYouTube:
+		return "#FF0000", "#FFFFFF"
+	case PlatformTikTok:
+		return "#000000", "#FFFFFF"
+	case PlatformLinkedIn:
+		return "#0A66C2", "#FFFFFF"
+	default:
+		return "#6B7280", "#FFFFFF"
+	}
+}

--- a/api/internal/domain/repository/link_repository.go
+++ b/api/internal/domain/repository/link_repository.go
@@ -1,0 +1,32 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/sg3t41/api/internal/domain/entity"
+)
+
+// LinkRepository リンクリポジトリインターフェース
+type LinkRepository interface {
+	// GetAll 全リンクを取得（表示順でソート）
+	GetAll(ctx context.Context, userID uuid.UUID) ([]*entity.Link, error)
+	
+	// GetByID IDでリンクを取得
+	GetByID(ctx context.Context, id int) (*entity.Link, error)
+	
+	// Create リンクを作成
+	Create(ctx context.Context, link *entity.Link) error
+	
+	// Update リンクを更新
+	Update(ctx context.Context, link *entity.Link) error
+	
+	// Delete リンクを削除
+	Delete(ctx context.Context, id int) error
+	
+	// GetActiveLinks アクティブなリンクのみを取得
+	GetActiveLinks(ctx context.Context, userID uuid.UUID) ([]*entity.Link, error)
+	
+	// UpdateOrder 表示順序を更新
+	UpdateOrder(ctx context.Context, linkID int, newOrder int) error
+}

--- a/api/internal/infrastructure/migration/migrations/000004_create_links_table.down.sql
+++ b/api/internal/infrastructure/migration/migrations/000004_create_links_table.down.sql
@@ -1,0 +1,4 @@
+-- リンク集テーブルの削除
+DROP TRIGGER IF EXISTS trigger_update_links_updated_at ON links;
+DROP FUNCTION IF EXISTS update_links_updated_at();
+DROP TABLE IF EXISTS links;

--- a/api/internal/infrastructure/migration/migrations/000004_create_links_table.up.sql
+++ b/api/internal/infrastructure/migration/migrations/000004_create_links_table.up.sql
@@ -1,0 +1,43 @@
+-- リンク集テーブルの作成
+CREATE TABLE IF NOT EXISTS links (
+    id SERIAL PRIMARY KEY,
+    title VARCHAR(100) NOT NULL,                   -- リンクタイトル
+    url TEXT NOT NULL,                             -- リンクURL
+    description TEXT,                              -- 説明文
+    platform VARCHAR(50) NOT NULL,                -- プラットフォーム名（twitter, instagram, github等）
+    icon_name VARCHAR(50),                         -- アイコン名
+    background_color VARCHAR(7) DEFAULT '#6B7280', -- 背景色（HEXコード）
+    text_color VARCHAR(7) DEFAULT '#FFFFFF',       -- テキスト色
+    order_index INTEGER DEFAULT 0,                -- 表示順序
+    is_active BOOLEAN DEFAULT true,               -- 有効フラグ
+    user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- インデックス作成
+CREATE INDEX idx_links_user_id ON links(user_id);
+CREATE INDEX idx_links_order_index ON links(order_index);
+CREATE INDEX idx_links_platform ON links(platform);
+CREATE INDEX idx_links_is_active ON links(is_active);
+
+-- updated_atの自動更新用トリガー
+CREATE OR REPLACE FUNCTION update_links_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+CREATE TRIGGER trigger_update_links_updated_at
+    BEFORE UPDATE ON links
+    FOR EACH ROW
+    EXECUTE FUNCTION update_links_updated_at();
+
+-- サンプルデータの挿入
+INSERT INTO links (title, url, description, platform, icon_name, background_color, text_color, order_index, user_id) VALUES
+('X (Twitter)', 'https://twitter.com/sg3t41', 'Follow me on X', 'twitter', 'twitter', '#1DA1F2', '#FFFFFF', 1, 1),
+('Instagram', 'https://instagram.com/sg3t41', 'My Instagram profile', 'instagram', 'instagram', '#E4405F', '#FFFFFF', 2, 1),
+('GitHub', 'https://github.com/sg3t41', 'Check out my repositories', 'github', 'github', '#333333', '#FFFFFF', 3, 1),
+('LINE', 'https://line.me/ti/p/sg3t41', 'Add me on LINE', 'line', 'line', '#00C300', '#FFFFFF', 4, 1);

--- a/api/internal/infrastructure/module.go
+++ b/api/internal/infrastructure/module.go
@@ -16,6 +16,7 @@ var Module = fx.Module("infrastructure",
 		provideUserRepository,
 		provideAuthRepository,
 		provideArticleRepository,
+		provideLinkRepository,
 	),
 )
 
@@ -43,4 +44,12 @@ func provideArticleRepository(cfg *config.Config, db *sql.DB) repository.Article
 		panic("Memory article repository not implemented")
 	}
 	return persistence.NewPostgresArticleRepository(db)
+}
+
+func provideLinkRepository(cfg *config.Config, db *sql.DB) repository.LinkRepository {
+	if cfg.UseMemoryDB {
+		// TODO: Implement memory link repository if needed
+		panic("Memory link repository not implemented")
+	}
+	return persistence.NewPostgresLinkRepository(persistence.NewSqlxDB(db))
 }

--- a/api/internal/infrastructure/persistence/common.go
+++ b/api/internal/infrastructure/persistence/common.go
@@ -1,11 +1,18 @@
 package persistence
 
 import (
+	"database/sql"
 	"fmt"
 	"strings"
 
+	"github.com/jmoiron/sqlx"
 	"github.com/sg3t41/api/internal/domain/repository"
 )
+
+// NewSqlxDB sql.DBからsqlx.DBを作成
+func NewSqlxDB(db *sql.DB) *sqlx.DB {
+	return sqlx.NewDb(db, "postgres")
+}
 
 // 共通のクエリビルダー機能
 

--- a/api/internal/infrastructure/persistence/postgres_link_repository.go
+++ b/api/internal/infrastructure/persistence/postgres_link_repository.go
@@ -1,0 +1,165 @@
+package persistence
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+	"github.com/sg3t41/api/internal/domain/entity"
+	"github.com/sg3t41/api/internal/domain/repository"
+)
+
+type postgresLinkRepository struct {
+	db *sqlx.DB
+}
+
+// NewPostgresLinkRepository リンクリポジトリの新しいインスタンスを作成
+func NewPostgresLinkRepository(db *sqlx.DB) repository.LinkRepository {
+	return &postgresLinkRepository{db: db}
+}
+
+// GetAll 全リンクを取得（表示順でソート）
+func (r *postgresLinkRepository) GetAll(ctx context.Context, userID uuid.UUID) ([]*entity.Link, error) {
+	query := `
+		SELECT id, title, url, description, platform, icon_name, 
+		       background_color, text_color, order_index, is_active, 
+		       user_id, created_at, updated_at
+		FROM links 
+		WHERE user_id = $1 
+		ORDER BY order_index ASC, created_at ASC`
+	
+	var links []*entity.Link
+	err := r.db.SelectContext(ctx, &links, query, userID)
+	if err != nil {
+		return nil, fmt.Errorf("リンク一覧の取得に失敗: %w", err)
+	}
+	
+	return links, nil
+}
+
+// GetByID IDでリンクを取得
+func (r *postgresLinkRepository) GetByID(ctx context.Context, id int) (*entity.Link, error) {
+	query := `
+		SELECT id, title, url, description, platform, icon_name, 
+		       background_color, text_color, order_index, is_active, 
+		       user_id, created_at, updated_at
+		FROM links 
+		WHERE id = $1`
+	
+	var link entity.Link
+	err := r.db.GetContext(ctx, &link, query, id)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("リンクが見つかりません: id=%d", id)
+		}
+		return nil, fmt.Errorf("リンクの取得に失敗: %w", err)
+	}
+	
+	return &link, nil
+}
+
+// Create リンクを作成
+func (r *postgresLinkRepository) Create(ctx context.Context, link *entity.Link) error {
+	query := `
+		INSERT INTO links (title, url, description, platform, icon_name, 
+		                  background_color, text_color, order_index, is_active, user_id)
+		VALUES (:title, :url, :description, :platform, :icon_name, 
+		        :background_color, :text_color, :order_index, :is_active, :user_id)
+		RETURNING id, created_at, updated_at`
+	
+	stmt, err := r.db.PrepareNamedContext(ctx, query)
+	if err != nil {
+		return fmt.Errorf("リンク作成のクエリ準備に失敗: %w", err)
+	}
+	defer stmt.Close()
+	
+	err = stmt.GetContext(ctx, link, link)
+	if err != nil {
+		return fmt.Errorf("リンクの作成に失敗: %w", err)
+	}
+	
+	return nil
+}
+
+// Update リンクを更新
+func (r *postgresLinkRepository) Update(ctx context.Context, link *entity.Link) error {
+	query := `
+		UPDATE links 
+		SET title = :title, url = :url, description = :description, 
+		    platform = :platform, icon_name = :icon_name, 
+		    background_color = :background_color, text_color = :text_color, 
+		    order_index = :order_index, is_active = :is_active,
+		    updated_at = CURRENT_TIMESTAMP
+		WHERE id = :id AND user_id = :user_id
+		RETURNING updated_at`
+	
+	stmt, err := r.db.PrepareNamedContext(ctx, query)
+	if err != nil {
+		return fmt.Errorf("リンク更新のクエリ準備に失敗: %w", err)
+	}
+	defer stmt.Close()
+	
+	err = stmt.GetContext(ctx, &link.UpdatedAt, link)
+	if err != nil {
+		return fmt.Errorf("リンクの更新に失敗: %w", err)
+	}
+	
+	return nil
+}
+
+// Delete リンクを削除
+func (r *postgresLinkRepository) Delete(ctx context.Context, id int) error {
+	query := `DELETE FROM links WHERE id = $1`
+	
+	result, err := r.db.ExecContext(ctx, query, id)
+	if err != nil {
+		return fmt.Errorf("リンクの削除に失敗: %w", err)
+	}
+	
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("削除結果の確認に失敗: %w", err)
+	}
+	
+	if rowsAffected == 0 {
+		return fmt.Errorf("削除対象のリンクが見つかりません: id=%d", id)
+	}
+	
+	return nil
+}
+
+// GetActiveLinks アクティブなリンクのみを取得
+func (r *postgresLinkRepository) GetActiveLinks(ctx context.Context, userID uuid.UUID) ([]*entity.Link, error) {
+	query := `
+		SELECT id, title, url, description, platform, icon_name, 
+		       background_color, text_color, order_index, is_active, 
+		       user_id, created_at, updated_at
+		FROM links 
+		WHERE user_id = $1 AND is_active = true 
+		ORDER BY order_index ASC, created_at ASC`
+	
+	var links []*entity.Link
+	err := r.db.SelectContext(ctx, &links, query, userID)
+	if err != nil {
+		return nil, fmt.Errorf("アクティブなリンク一覧の取得に失敗: %w", err)
+	}
+	
+	return links, nil
+}
+
+// UpdateOrder 表示順序を更新
+func (r *postgresLinkRepository) UpdateOrder(ctx context.Context, linkID int, newOrder int) error {
+	query := `
+		UPDATE links 
+		SET order_index = $1, updated_at = CURRENT_TIMESTAMP
+		WHERE id = $2`
+	
+	_, err := r.db.ExecContext(ctx, query, newOrder, linkID)
+	if err != nil {
+		return fmt.Errorf("表示順序の更新に失敗: %w", err)
+	}
+	
+	return nil
+}

--- a/api/internal/interfaces/dto/link_dto.go
+++ b/api/internal/interfaces/dto/link_dto.go
@@ -1,0 +1,55 @@
+package dto
+
+// CreateLinkRequest リンク作成リクエスト
+type CreateLinkRequest struct {
+	Title           string  `json:"title" binding:"required,max=100"`
+	URL             string  `json:"url" binding:"required,url"`
+	Description     *string `json:"description,omitempty"`
+	Platform        string  `json:"platform" binding:"required,max=50"`
+	IconName        *string `json:"icon_name,omitempty"`
+	BackgroundColor *string `json:"background_color,omitempty"`
+	TextColor       *string `json:"text_color,omitempty"`
+	OrderIndex      *int    `json:"order_index,omitempty"`
+	IsActive        *bool   `json:"is_active,omitempty"`
+}
+
+// UpdateLinkRequest リンク更新リクエスト
+type UpdateLinkRequest struct {
+	Title           *string `json:"title,omitempty" binding:"omitempty,max=100"`
+	URL             *string `json:"url,omitempty" binding:"omitempty,url"`
+	Description     *string `json:"description,omitempty"`
+	Platform        *string `json:"platform,omitempty" binding:"omitempty,max=50"`
+	IconName        *string `json:"icon_name,omitempty"`
+	BackgroundColor *string `json:"background_color,omitempty"`
+	TextColor       *string `json:"text_color,omitempty"`
+	OrderIndex      *int    `json:"order_index,omitempty"`
+	IsActive        *bool   `json:"is_active,omitempty"`
+}
+
+// LinkResponse リンク情報のレスポンス
+type LinkResponse struct {
+	ID              int     `json:"id"`
+	Title           string  `json:"title"`
+	URL             string  `json:"url"`
+	Description     *string `json:"description"`
+	Platform        string  `json:"platform"`
+	IconName        *string `json:"icon_name"`
+	BackgroundColor string  `json:"background_color"`
+	TextColor       string  `json:"text_color"`
+	OrderIndex      int     `json:"order_index"`
+	IsActive        bool    `json:"is_active"`
+	UserID          string  `json:"user_id"`
+	CreatedAt       string  `json:"created_at"`
+	UpdatedAt       string  `json:"updated_at"`
+}
+
+// UpdateOrderRequest 表示順序更新リクエスト
+type UpdateOrderRequest struct {
+	OrderIndex int `json:"order_index" binding:"required,min=0"`
+}
+
+// LinkListResponse リンク一覧レスポンス
+type LinkListResponse struct {
+	Links []*LinkResponse `json:"links"`
+	Total int             `json:"total"`
+}

--- a/api/internal/interfaces/handler/link_handler.go
+++ b/api/internal/interfaces/handler/link_handler.go
@@ -1,0 +1,317 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/sg3t41/api/internal/domain/entity"
+	"github.com/sg3t41/api/internal/domain/repository"
+	"github.com/sg3t41/api/internal/interfaces/dto"
+	"go.uber.org/zap"
+)
+
+// LinkHandler リンク管理ハンドラー
+type LinkHandler struct {
+	linkRepo repository.LinkRepository
+	logger   *zap.Logger
+}
+
+// NewLinkHandler リンクハンドラーの新しいインスタンスを作成
+func NewLinkHandler(linkRepo repository.LinkRepository, logger *zap.Logger) *LinkHandler {
+	return &LinkHandler{
+		linkRepo: linkRepo,
+		logger:   logger,
+	}
+}
+
+// GetLinks リンク一覧を取得
+func (h *LinkHandler) GetLinks(c *gin.Context) {
+	userID := getUserIDFromContext(c)
+	
+	// activeパラメータをチェック
+	activeOnly := c.Query("active") == "true"
+	
+	var links []*entity.Link
+	var err error
+	
+	if activeOnly {
+		links, err = h.linkRepo.GetActiveLinks(c.Request.Context(), userID)
+	} else {
+		links, err = h.linkRepo.GetAll(c.Request.Context(), userID)
+	}
+	
+	if err != nil {
+		h.logger.Error("リンク一覧の取得に失敗", zap.Error(err))
+		respondInternalError(c, "リンク一覧の取得に失敗しました")
+		return
+	}
+	
+	// レスポンスに変換
+	linkResponses := make([]*dto.LinkResponse, len(links))
+	for i, link := range links {
+		linkResponses[i] = h.entityToResponse(link)
+	}
+	
+	response := &dto.LinkListResponse{
+		Links: linkResponses,
+		Total: len(linkResponses),
+	}
+	
+	c.JSON(http.StatusOK, response)
+}
+
+// GetLink 特定のリンクを取得
+func (h *LinkHandler) GetLink(c *gin.Context) {
+	linkID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		respondBadRequest(c, "無効なリンクIDです")
+		return
+	}
+	
+	link, err := h.linkRepo.GetByID(c.Request.Context(), linkID)
+	if err != nil {
+		h.logger.Error("リンクの取得に失敗", zap.Error(err))
+		respondInternalError(c, "リンクの取得に失敗しました")
+		return
+	}
+	
+	c.JSON(http.StatusOK, h.entityToResponse(link))
+}
+
+// CreateLink リンクを作成
+func (h *LinkHandler) CreateLink(c *gin.Context) {
+	userID := getUserIDFromContext(c)
+	
+	var req dto.CreateLinkRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		respondBadRequest(c, "リクエストデータが無効です: "+err.Error())
+		return
+	}
+	
+	// エンティティに変換
+	link := &entity.Link{
+		Title:       req.Title,
+		URL:         req.URL,
+		Description: req.Description,
+		Platform:    req.Platform,
+		IconName:    req.IconName,
+		UserID:      userID,
+	}
+	
+	// デフォルト値を設定
+	h.setDefaultValues(link, &req)
+	
+	// リンクを作成
+	if err := h.linkRepo.Create(c.Request.Context(), link); err != nil {
+		h.logger.Error("リンクの作成に失敗", zap.Error(err))
+		respondInternalError(c, "リンクの作成に失敗しました")
+		return
+	}
+	
+	h.logger.Info("リンクを作成しました", 
+		zap.Int("link_id", link.ID),
+		zap.String("title", link.Title),
+		zap.String("user_id", userID.String()))
+	
+	c.JSON(http.StatusCreated, h.entityToResponse(link))
+}
+
+// UpdateLink リンクを更新
+func (h *LinkHandler) UpdateLink(c *gin.Context) {
+	linkID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		respondBadRequest(c, "無効なリンクIDです")
+		return
+	}
+	
+	userID := getUserIDFromContext(c)
+	
+	var req dto.UpdateLinkRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		respondBadRequest(c, "リクエストデータが無効です: "+err.Error())
+		return
+	}
+	
+	// 既存のリンクを取得
+	link, err := h.linkRepo.GetByID(c.Request.Context(), linkID)
+	if err != nil {
+		h.logger.Error("リンクの取得に失敗", zap.Error(err))
+		respondInternalError(c, "リンクの取得に失敗しました")
+		return
+	}
+	
+	// 権限チェック
+	if link.UserID != userID {
+		respondBadRequest(c, "このリンクを更新する権限がありません")
+		return
+	}
+	
+	// フィールドを更新
+	h.updateLinkFields(link, &req)
+	
+	// リンクを更新
+	if err := h.linkRepo.Update(c.Request.Context(), link); err != nil {
+		h.logger.Error("リンクの更新に失敗", zap.Error(err))
+		respondInternalError(c, "リンクの更新に失敗しました")
+		return
+	}
+	
+	h.logger.Info("リンクを更新しました", 
+		zap.Int("link_id", link.ID),
+		zap.String("user_id", userID.String()))
+	
+	c.JSON(http.StatusOK, h.entityToResponse(link))
+}
+
+// DeleteLink リンクを削除
+func (h *LinkHandler) DeleteLink(c *gin.Context) {
+	linkID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		respondBadRequest(c, "無効なリンクIDです")
+		return
+	}
+	
+	userID := getUserIDFromContext(c)
+	
+	// 既存のリンクを取得して権限チェック
+	link, err := h.linkRepo.GetByID(c.Request.Context(), linkID)
+	if err != nil {
+		h.logger.Error("リンクの取得に失敗", zap.Error(err))
+		respondInternalError(c, "リンクの取得に失敗しました")
+		return
+	}
+	
+	if link.UserID != userID {
+		respondBadRequest(c, "このリンクを削除する権限がありません")
+		return
+	}
+	
+	// リンクを削除
+	if err := h.linkRepo.Delete(c.Request.Context(), linkID); err != nil {
+		h.logger.Error("リンクの削除に失敗", zap.Error(err))
+		respondInternalError(c, "リンクの削除に失敗しました")
+		return
+	}
+	
+	h.logger.Info("リンクを削除しました", 
+		zap.Int("link_id", linkID),
+		zap.String("user_id", userID.String()))
+	
+	respondWithSuccess(c, "リンクを削除しました")
+}
+
+// UpdateLinkOrder リンクの表示順序を更新
+func (h *LinkHandler) UpdateLinkOrder(c *gin.Context) {
+	linkID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		respondBadRequest(c, "無効なリンクIDです")
+		return
+	}
+	
+	var req dto.UpdateOrderRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		respondBadRequest(c, "リクエストデータが無効です: "+err.Error())
+		return
+	}
+	
+	if err := h.linkRepo.UpdateOrder(c.Request.Context(), linkID, req.OrderIndex); err != nil {
+		h.logger.Error("表示順序の更新に失敗", zap.Error(err))
+		respondInternalError(c, "表示順序の更新に失敗しました")
+		return
+	}
+	
+	h.logger.Info("表示順序を更新しました", 
+		zap.Int("link_id", linkID),
+		zap.Int("order_index", req.OrderIndex))
+	
+	respondWithSuccess(c, "表示順序を更新しました")
+}
+
+// Helper methods
+
+func (h *LinkHandler) entityToResponse(link *entity.Link) *dto.LinkResponse {
+	return &dto.LinkResponse{
+		ID:              link.ID,
+		Title:           link.Title,
+		URL:             link.URL,
+		Description:     link.Description,
+		Platform:        link.Platform,
+		IconName:        link.IconName,
+		BackgroundColor: link.BackgroundColor,
+		TextColor:       link.TextColor,
+		OrderIndex:      link.OrderIndex,
+		IsActive:        link.IsActive,
+		UserID:          link.UserID.String(),
+		CreatedAt:       link.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		UpdatedAt:       link.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
+	}
+}
+
+func (h *LinkHandler) setDefaultValues(link *entity.Link, req *dto.CreateLinkRequest) {
+	// プラットフォームのデフォルト色を設定
+	platform := entity.LinkPlatform(req.Platform)
+	defaultBg, defaultText := platform.GetDefaultColors()
+	
+	if req.BackgroundColor != nil {
+		link.BackgroundColor = *req.BackgroundColor
+	} else {
+		link.BackgroundColor = defaultBg
+	}
+	
+	if req.TextColor != nil {
+		link.TextColor = *req.TextColor
+	} else {
+		link.TextColor = defaultText
+	}
+	
+	if req.OrderIndex != nil {
+		link.OrderIndex = *req.OrderIndex
+	} else {
+		link.OrderIndex = 0
+	}
+	
+	if req.IsActive != nil {
+		link.IsActive = *req.IsActive
+	} else {
+		link.IsActive = true
+	}
+}
+
+func (h *LinkHandler) updateLinkFields(link *entity.Link, req *dto.UpdateLinkRequest) {
+	if req.Title != nil {
+		link.Title = *req.Title
+	}
+	if req.URL != nil {
+		link.URL = *req.URL
+	}
+	if req.Description != nil {
+		link.Description = req.Description
+	}
+	if req.Platform != nil {
+		link.Platform = *req.Platform
+	}
+	if req.IconName != nil {
+		link.IconName = req.IconName
+	}
+	if req.BackgroundColor != nil {
+		link.BackgroundColor = *req.BackgroundColor
+	}
+	if req.TextColor != nil {
+		link.TextColor = *req.TextColor
+	}
+	if req.OrderIndex != nil {
+		link.OrderIndex = *req.OrderIndex
+	}
+	if req.IsActive != nil {
+		link.IsActive = *req.IsActive
+	}
+}
+
+// getUserIDFromContext コンテキストからユーザーIDを取得（仮実装）
+func getUserIDFromContext(c *gin.Context) uuid.UUID {
+	// TODO: 認証機能実装後に適切に実装
+	userID, _ := uuid.Parse("6222a0b4-90c7-4cfa-ab26-4131155ff544")
+	return userID // 暫定的に固定値
+}

--- a/api/internal/interfaces/module.go
+++ b/api/internal/interfaces/module.go
@@ -18,6 +18,7 @@ var Module = fx.Module("interfaces",
 		handler.NewArticleHandler,
 		handler.NewUploadHandler,
 		handler.NewLineHandler,
+		handler.NewLinkHandler,
 		fx.Annotate(
 			handler.NewLineBotHandler,
 			fx.As(new(handler.LineBotHandler)),

--- a/api/internal/interfaces/router/router.go
+++ b/api/internal/interfaces/router/router.go
@@ -21,6 +21,7 @@ type Router struct {
 	uploadHandler      *handler.UploadHandler
 	lineHandler        *handler.LineHandler
 	lineBotHandler     handler.LineBotHandler
+	linkHandler        *handler.LinkHandler
 	authMiddleware     *middleware.AuthMiddleware
 	adminMiddleware    *middleware.AdminMiddleware
 	validationMiddleware *middleware.ValidationMiddleware
@@ -35,6 +36,7 @@ func NewRouter(
 	uploadHandler *handler.UploadHandler,
 	lineHandler *handler.LineHandler,
 	lineBotHandler handler.LineBotHandler,
+	linkHandler *handler.LinkHandler,
 	authMiddleware *middleware.AuthMiddleware,
 	adminMiddleware *middleware.AdminMiddleware,
 ) *Router {
@@ -57,6 +59,7 @@ func NewRouter(
 		uploadHandler:      uploadHandler,
 		lineHandler:        lineHandler,
 		lineBotHandler:     lineBotHandler,
+		linkHandler:        linkHandler,
 		authMiddleware:     authMiddleware,
 		adminMiddleware:    adminMiddleware,
 		validationMiddleware: validationMiddleware,
@@ -101,6 +104,23 @@ func (r *Router) SetupRoutes() {
 		lineBot := v1.Group("/linebot")
 		{
 			lineBot.POST("/webhook", r.lineBotHandler.Webhook)
+		}
+
+		// Link endpoints
+		links := v1.Group("/links")
+		{
+			// 公開エンドポイント（認証不要）
+			links.GET("", r.linkHandler.GetLinks)
+			links.GET("/:id", r.linkHandler.GetLink)
+			
+			// 管理エンドポイント（認証必要）
+			linksProtected := links.Use(r.authMiddleware.RequireAuth())
+			{
+				linksProtected.POST("", r.linkHandler.CreateLink)
+				linksProtected.PUT("/:id", r.linkHandler.UpdateLink)
+				linksProtected.DELETE("/:id", r.linkHandler.DeleteLink)
+				linksProtected.PATCH("/:id/order", r.linkHandler.UpdateLinkOrder)
+			}
 		}
 
 		// User endpoints

--- a/api/migrations/000004_create_links_table.down.sql
+++ b/api/migrations/000004_create_links_table.down.sql
@@ -1,0 +1,4 @@
+-- リンク集テーブルの削除
+DROP TRIGGER IF EXISTS trigger_update_links_updated_at ON links;
+DROP FUNCTION IF EXISTS update_links_updated_at();
+DROP TABLE IF EXISTS links;

--- a/api/migrations/000004_create_links_table.up.sql
+++ b/api/migrations/000004_create_links_table.up.sql
@@ -1,0 +1,43 @@
+-- リンク集テーブルの作成
+CREATE TABLE IF NOT EXISTS links (
+    id SERIAL PRIMARY KEY,
+    title VARCHAR(100) NOT NULL,                   -- リンクタイトル
+    url TEXT NOT NULL,                             -- リンクURL
+    description TEXT,                              -- 説明文
+    platform VARCHAR(50) NOT NULL,                -- プラットフォーム名（twitter, instagram, github等）
+    icon_name VARCHAR(50),                         -- アイコン名
+    background_color VARCHAR(7) DEFAULT '#6B7280', -- 背景色（HEXコード）
+    text_color VARCHAR(7) DEFAULT '#FFFFFF',       -- テキスト色
+    order_index INTEGER DEFAULT 0,                -- 表示順序
+    is_active BOOLEAN DEFAULT true,               -- 有効フラグ
+    user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- インデックス作成
+CREATE INDEX idx_links_user_id ON links(user_id);
+CREATE INDEX idx_links_order_index ON links(order_index);
+CREATE INDEX idx_links_platform ON links(platform);
+CREATE INDEX idx_links_is_active ON links(is_active);
+
+-- updated_atの自動更新用トリガー
+CREATE OR REPLACE FUNCTION update_links_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+CREATE TRIGGER trigger_update_links_updated_at
+    BEFORE UPDATE ON links
+    FOR EACH ROW
+    EXECUTE FUNCTION update_links_updated_at();
+
+-- サンプルデータの挿入
+INSERT INTO links (title, url, description, platform, icon_name, background_color, text_color, order_index, user_id) VALUES
+('X (Twitter)', 'https://twitter.com/sg3t41', 'Follow me on X', 'twitter', 'twitter', '#1DA1F2', '#FFFFFF', 1, '6222a0b4-90c7-4cfa-ab26-4131155ff544'),
+('Instagram', 'https://instagram.com/sg3t41', 'My Instagram profile', 'instagram', 'instagram', '#E4405F', '#FFFFFF', 2, '6222a0b4-90c7-4cfa-ab26-4131155ff544'),
+('GitHub', 'https://github.com/sg3t41', 'Check out my repositories', 'github', 'github', '#333333', '#FFFFFF', 3, '6222a0b4-90c7-4cfa-ab26-4131155ff544'),
+('LINE', 'https://line.me/ti/p/sg3t41', 'Add me on LINE', 'line', 'line', '#00C300', '#FFFFFF', 4, '6222a0b4-90c7-4cfa-ab26-4131155ff544');

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -6,7 +6,7 @@ WORKDIR /app
 COPY package.json package-lock.json* ./
 
 # Install dependencies
-RUN npm ci
+RUN npm install
 
 # Copy source code
 COPY . .

--- a/frontend/app/links/page.tsx
+++ b/frontend/app/links/page.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { FiTwitter, FiInstagram, FiGithub, FiExternalLink, FiYoutube, FiLinkedin } from 'react-icons/fi';
+import { SiLine, SiTiktok } from 'react-icons/si';
+
+interface Link {
+  id: number;
+  title: string;
+  url: string;
+  description?: string;
+  platform: string;
+  icon_name?: string;
+  background_color: string;
+  text_color: string;
+  order_index: number;
+  is_active: boolean;
+}
+
+interface LinkResponse {
+  links: Link[];
+  total: number;
+}
+
+const platformIcons: Record<string, React.ComponentType<{ className?: string }>> = {
+  twitter: FiTwitter,
+  instagram: FiInstagram,
+  github: FiGithub,
+  line: SiLine,
+  youtube: FiYoutube,
+  tiktok: SiTiktok,
+  linkedin: FiLinkedin,
+  website: FiExternalLink,
+};
+
+export default function LinksPage() {
+  const [links, setLinks] = useState<Link[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchLinks();
+  }, []);
+
+  const fetchLinks = async () => {
+    try {
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/links?active=true`);
+      if (!response.ok) {
+        throw new Error('リンクの取得に失敗しました');
+      }
+      const data: LinkResponse = await response.json();
+      setLinks(data.links);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'エラーが発生しました');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getIconComponent = (platform: string) => {
+    return platformIcons[platform] || FiExternalLink;
+  };
+
+  const handleLinkClick = (url: string) => {
+    window.open(url, '_blank', 'noopener,noreferrer');
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-purple-100 via-pink-50 to-orange-100 flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-600"></div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-purple-100 via-pink-50 to-orange-100 flex items-center justify-center">
+        <div className="text-center p-8 bg-white rounded-xl shadow-lg">
+          <div className="text-red-500 text-lg font-medium mb-2">エラー</div>
+          <div className="text-gray-600">{error}</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-purple-100 via-pink-50 to-orange-100 py-8 px-4">
+      <div className="max-w-md mx-auto">
+        {/* プロフィールヘッダー */}
+        <div className="text-center mb-8">
+          <h1 className="text-2xl font-bold text-gray-800 mb-2">sg3t41</h1>
+        </div>
+
+        {/* リンクリスト */}
+        <div className="space-y-4">
+          {links.length === 0 ? (
+            <div className="text-center py-12">
+              <div className="text-gray-500 text-lg">リンクがありません</div>
+            </div>
+          ) : (
+            links.map((link) => {
+              const IconComponent = getIconComponent(link.platform);
+              return (
+                <button
+                  key={link.id}
+                  onClick={() => handleLinkClick(link.url)}
+                  className="w-full p-4 rounded-2xl shadow-lg hover:shadow-xl transform hover:-translate-y-1 transition-all duration-200 text-left group"
+                  style={{
+                    backgroundColor: link.background_color,
+                    color: link.text_color,
+                  }}
+                >
+                  <div className="flex items-center space-x-4">
+                    <div className="flex-shrink-0">
+                      <IconComponent className="w-6 h-6" />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <div className="font-semibold text-lg truncate">
+                        {link.title}
+                      </div>
+                      {link.description && (
+                        <div className="text-sm opacity-90 truncate mt-1">
+                          {link.description}
+                        </div>
+                      )}
+                    </div>
+                    <div className="flex-shrink-0 opacity-70 group-hover:opacity-100 transition-opacity">
+                      <FiExternalLink className="w-5 h-5" />
+                    </div>
+                  </div>
+                </button>
+              );
+            })
+          )}
+        </div>
+
+        {/* フッター */}
+        <div className="text-center mt-12 text-gray-500 text-sm">
+          <p>© 2025 sg3t41. All rights reserved.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "next": "15.3.4",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "react-icons": "^5.0.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -5209,6 +5210,15 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "next": "15.3.4",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-icons": "^5.0.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
データベース設計、API、フロントエンドを含む完全なリンク集機能を追加
- linksテーブル作成（UUID対応）
- CRUD API実装（/api/v1/links）
- lit.link風UI実装
- プラットフォーム別アイコン・ブランドカラー対応
- レスポンシブデザイン採用
- サンプルデータ（Twitter、Instagram、GitHub、LINE）追加